### PR TITLE
Add AI travel planner example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Full-stack-development
+# Full Stack Development
+
+This repository contains sample projects for learning full-stack web development. Each project demonstrates how to combine front-end and back-end technologies to create a functional application.
+
+## Getting Started
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm start
+```
+
+This will launch a local server on `http://localhost:3000`.
+
+## Project
+
+Currently, the repository features a simple travel itinerary planner with a minimal AI-based suggestion engine.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Travel Planner</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Travel Itinerary Planner</h1>
+    <form id="plan-form">
+        <label for="destination">Destination:</label>
+        <input type="text" id="destination" required>
+        <label for="days">Number of Days:</label>
+        <input type="number" id="days" min="1" max="14" required>
+        <button type="submit">Plan Trip</button>
+    </form>
+    <pre id="result"></pre>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/client/script.js
+++ b/client/script.js
@@ -1,0 +1,14 @@
+document.getElementById('plan-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const destination = document.getElementById('destination').value;
+    const days = document.getElementById('days').value;
+
+    const response = await fetch('/api/itinerary', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ destination, days })
+    });
+
+    const data = await response.json();
+    document.getElementById('result').textContent = data.plan;
+});

--- a/client/style.css
+++ b/client/style.css
@@ -1,0 +1,13 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2em;
+}
+
+form {
+    margin-bottom: 1em;
+}
+
+label {
+    display: block;
+    margin-top: 0.5em;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "travel-itinerary-planner",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'client')));
+
+function generateItinerary(destination, days) {
+  const activities = [
+    'Visit a local museum',
+    'Explore downtown',
+    'Check out popular restaurants',
+    'Enjoy a city tour',
+    'Take a day trip to nearby attractions'
+  ];
+  let plan = `Trip to ${destination}\n`;
+  for (let i = 1; i <= days; i++) {
+    const activity = activities[i % activities.length];
+    plan += `Day ${i}: ${activity}\n`;
+  }
+  return plan;
+}
+
+app.post('/api/itinerary', (req, res) => {
+  const { destination, days } = req.body;
+  const plan = generateItinerary(destination, Number(days));
+  res.json({ plan });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add simple Express server and client files for an AI travel itinerary planner
- document how to start the app in README

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68418d72ef84832dab65dce42499ba44